### PR TITLE
Add hint for mac address format

### DIFF
--- a/js-version/index.html
+++ b/js-version/index.html
@@ -18,7 +18,7 @@
 					<h3>SuperMicro IPMI License Generator</h3>
 					<p>This is a helpful tool, It can generate the SuperMicro's motherboard IPMI Activate License keys, And it is free and open-source.</p>
 					<hr />
-					<p>First, input your IPMI BMC-MAC here:</p>
+					<p>First, input your IPMI BMC-MAC here (example "0c:c4:7a:3e:2f:de"):</p>
 					<p><div class="input-group">
 						<input id="input" class="form-control" placeholder="You BMC-MAC" />
 						<span class="input-group-btn">


### PR DESCRIPTION
To improve UX, add mac address example: in SuperMicro BMC can be found also using "-" as separator,
but that will produce a non working license.